### PR TITLE
feat: Fragment support to have multiple children in a component

### DIFF
--- a/reacton/__init__.py
+++ b/reacton/__init__.py
@@ -11,6 +11,7 @@ from . import _version
 
 __version__ = _version.__version__
 from .core import (
+    Fragment,
     component,
     component_interactive,
     create_context,
@@ -34,6 +35,7 @@ from .core import (
 )
 
 __all__ = [
+    "Fragment",
     "__version__",
     "component",
     "value_component",

--- a/reacton/core_test.py
+++ b/reacton/core_test.py
@@ -3142,3 +3142,25 @@ def test_memory_leak(component):
     del rc
     gc.collect()
     assert weak_rc() is None
+
+
+def test_fragment():
+    @reacton.component
+    def Children():
+        with reacton.Fragment():
+            w.Button(description="1")
+            w.Button(description="2")
+
+    @reacton.component
+    def Test():
+        with w.VBox():
+            Children()
+
+    box, rc = react.render(Test(), handle_error=False)
+    vbox = rc.find(widgets.VBox).widget
+    assert len(vbox.children) == 2
+    assert isinstance(vbox.children[0], widgets.Button)
+    assert isinstance(vbox.children[1], widgets.Button)
+    assert vbox.children[0].description == "1"
+    assert vbox.children[1].description == "2"
+    rc.close()

--- a/reacton/ipyvuetify.py
+++ b/reacton/ipyvuetify.py
@@ -2,6 +2,6 @@
 from .ipyvue import use_event  # noqa: F401
 
 try:
-    from ipyvuetify.components import *  # noqa: F401, F403
+    from ipyvuetify.components import *  # type: ignore  # noqa: F401, F403
 except ModuleNotFoundError:
-    from reacton.deprecated.ipyvuetify import *  # noqa: F401, F403
+    from reacton.deprecated.ipyvuetify import *  # type: ignore  # noqa: F401, F403


### PR DESCRIPTION
Similar to React, where children in a Fragment will be 'extended' to a parent list (like children) instead of 'appended'

Example

```python
import reacton
import reacton.ipywidgets as w

@reacton.component
def Children():
    with reacton.Fragment():  # option for reacton, mandatory for solara
        w.Button(description="1")
        w.Button(description="2")

@reacton.component
def Test():
    with w.VBox():
        Children()
Test()
```

Since solara overrides the '_default_container', this is mandatory to use with solara (even when just imported). For solara v2 we will probably also start using fragments.