### PR TITLE
fix: do not call effects when an exceptions occurs.

### DIFF
--- a/reacton/core.py
+++ b/reacton/core.py
@@ -1891,6 +1891,9 @@ class _RenderContext:
                                         context.needs_render = True
                                 effect = child_context.effects[effect_index] = effect.next
                                 try:
+                                    if child_context.exceptions_self or child_context.exceptions_children:
+                                        # we had an exception, so we skip the effect (not the cleanup)
+                                        continue
                                     effect()
                                 except BaseException as e:
                                     context.exceptions_self.append(e)
@@ -1899,6 +1902,9 @@ class _RenderContext:
                                     context.needs_render = True
                         else:
                             try:
+                                if child_context.exceptions_self or child_context.exceptions_children:
+                                    # we had an exception, so we skip the effect (not the cleanup)
+                                    continue
                                 effect()
                             except BaseException as e:
                                 context.exceptions_self.append(e)

--- a/reacton/core_test.py
+++ b/reacton/core_test.py
@@ -1998,6 +1998,28 @@ def test_recover_exception_in_widget_update(Container1, Container2):
     rc.close()
 
 
+def test_exception_in_child_no_run_effect():
+    set_fail = None
+
+    mock = unittest.mock.Mock()
+
+    @react.component
+    def Test():
+        nonlocal set_fail
+        children = v.Btn(children=[1])
+        # we do not want to run this effect
+        use_effect(mock, [])
+        return children
+
+    box, rc = react.render(Test(), handle_error=True)
+    assert not mock.called
+
+    assert not rc.find(ipyvuetify.Btn)
+    assert "Traceback" in rc.find(ipywidgets.HTML).widget.value
+
+    rc.close()
+
+
 def test_state_get():
     set_value = None
 


### PR DESCRIPTION
This can lead to a situation where get_widget returns None, in our case this led to use_event trying to call .on_event on None.