### PR TITLE
fix: _remove_element failing silently when child objects left over

### DIFF
--- a/reacton/core.py
+++ b/reacton/core.py
@@ -2125,6 +2125,17 @@ class _RenderContext:
                 new_parent_key = join_key(parent_key, key)
                 self._remove_element(self.context.root_element, "/", parent_key=new_parent_key)
             finally:
+                try:
+                    assert not child_context.elements, f"left over elements {child_context.elements}"
+                    assert not child_context.element_to_widget, f"left over element_to_widget {child_context.element_to_widget}"
+                    assert not child_context.widgets, f"left over widgets {child_context.widgets}"
+                    assert not child_context.children, f"left over children {child_context.children}"
+                    assert not child_context.owns, f"left over owns {child_context.owns}"
+                    # TODO: this is not the case when an exception occurs
+                    # assert not child_context.children_next, f"left over children {child_context.children_next}"
+                except Exception as e:
+                    child_context.exceptions_self.append(e)
+
                 # restore context
                 self.context = context
             if child_context.exceptions_self or child_context.exceptions_children and not child_context.exception_handler:
@@ -2159,14 +2170,6 @@ class _RenderContext:
         if el in context.element_to_widget:
             del context.element_to_widget[el]
         del context.elements[key]
-        if isinstance(el.component, ComponentFunction):
-            assert not child_context.elements, f"left over elements {child_context.elements}"
-            assert not child_context.element_to_widget, f"left over element_to_widget {child_context.element_to_widget}"
-            assert not child_context.widgets, f"left over widgets {child_context.widgets}"
-            assert not child_context.children, f"left over children {child_context.children}"
-            assert not child_context.owns, f"left over owns {child_context.owns}"
-            # TODO: this is not the case when an exception occurs
-            # assert not child_context.children_next, f"left over children {child_context.children_next}"
 
     def _visit_children(self, el: Element, default_key: str, parent_key: str, f: Callable):
         assert self.context is not None


### PR DESCRIPTION
This used to happen with Solara, I think because https://github.com/widgetti/solara/blob/c8ca20f8b137058e7e2374ed2a024320808875be/solara/server/patch.py#L521-L539 would react to a widget being (unexpectedly) deleted before the exception from reacton would be rendered.

The reason why we could have a situation where no exception was displayed would also be fixed by this change - previously any `AssertionError`s were not being added to any context exception list