### PR TITLE
feat: relax typing_extensions version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {file = "LICENSE"}
 dynamic = ["version", "description"]
 dependencies = [
     "ipywidgets",
-    "typing_extensions >= 4.1.1",
+    "typing_extensions >= 3.7.0",
 ]
 
 classifiers = [

--- a/reacton/core.py
+++ b/reacton/core.py
@@ -40,7 +40,6 @@ from warnings import warn
 import ipywidgets
 import ipywidgets as widgets
 import traitlets
-import typing_extensions
 from typing_extensions import Literal, Protocol
 
 import reacton.logging  # noqa: F401  # has sidefx
@@ -87,7 +86,12 @@ W = TypeVar("W")  # used for widgets
 V = TypeVar("V")  # used for value type of widget
 V2 = TypeVar("V2")  # used for value type of widget
 E = TypeVar("E")  # used for elements
-P = typing_extensions.ParamSpec("P")
+
+try:
+    from typing_extensions import ParamSpec
+    P = ParamSpec("P")
+except ImportError:
+    P = ...
 
 WidgetOrList = Union[widgets.Widget, List[widgets.Widget]]
 EffectCleanupCallable = Callable[[], None]


### PR DESCRIPTION
Hello!
I wanted to use Reacton in a project where the version of typing_extensions is pinned to 3.7.4.1 (python3-typing-extensions package from Ubuntu 20.04). However, due to ParamSpec usage, reacton requires at least 4.1.1. I suggest to relax the requirements, as missing type definition does not break anything.

Here I used a simple try-except to set type alias to ellipsis on failed import. Not entirely sure if it is correct as [documentation](https://docs.python.org/3.6/library/typing.html#typing.Callable) specifies a **literal ellipsis** as a possible type argument for Callable, but with CPython 3.6+ this works fine.