### PR TITLE
chore: add ruff to generate dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 ]
 
 generate = [
+    "ruff; python_version > '3.6'",
     "black",
     "bqplot",
     "jinja2",


### PR DESCRIPTION
Since we now use Ruff when generating elements (#40), it should be included in the generate optional dependencies in addition to dev dependencies. Discovered through [this ipyvuetify test run](https://github.com/widgetti/ipyvuetify/actions/runs/13237490690/job/36945332915?pr=328)