### PR TITLE
Accept a function as initial value for use_state

### DIFF
--- a/reacton/core.py
+++ b/reacton/core.py
@@ -766,7 +766,9 @@ def get_widget(el: Element):
     raise KeyError(f"Element {el} not found in all known widgets")  # for the component {context.widgets}")
 
 
-def use_state(initial: T, key: str = None, eq: Callable[[Any, Any], bool] = None) -> Tuple[T, Callable[[Union[T, Callable[[T], T]]], None]]:
+def use_state(
+    initial: Union[T, Callable[[], T]], key: str = None, eq: Callable[[Any, Any], bool] = None
+) -> Tuple[T, Callable[[Union[T, Callable[[T], T]]], None]]:
     """Returns a `(value, setter)` tuple that is used to manage state in a component.
 
     This function can only be called from a component function.
@@ -1261,6 +1263,9 @@ class _RenderContext:
             key = str(self.context.state_index)
             self.context.state_index += 1
         if key not in self.context.state:
+            if callable(initial):
+                initial = initial()
+
             self.context.state[key] = initial
             if isinstance(initial, (list, dict, set)):
                 self.context.state_metadata[key] = len(initial)

--- a/reacton/core_test.py
+++ b/reacton/core_test.py
@@ -1620,6 +1620,32 @@ def test_use_state_with_function():
     rc.close()
 
 
+def test_use_state_initial_function():
+    initial_func = unittest.mock.Mock()
+    initial_func.return_value = 10
+
+    @react.component
+    def ButtonClick(label="Hi"):
+        clicks, set_clicks = react.use_state(initial_func)
+
+        def update_click(click):
+            return click + 1
+
+        return w.Button(description=f"{label}: Clicked {clicks} times", on_click=lambda: set_clicks(update_click))
+
+    clicker, rc = react.render_fixed(ButtonClick())
+
+    initial_func.assert_called_once()
+    assert clicker.description == "Hi: Clicked 10 times"
+
+    clicker.click()
+
+    initial_func.assert_called_once()
+    assert clicker.description == "Hi: Clicked 11 times"
+
+    rc.close()
+
+
 def test_use_ref():
     last = None
 


### PR DESCRIPTION
This PR adds the possibility to use a function as inital value for `use_state`. This is in line with how React works: https://react.dev/reference/react/useState#usestate

When it's costly to calculate the initial value you don't want to rerun it every time the component is rerendered. Therefore, we need to only calculate it once.