### PR TITLE
fix: a render waiting on the lock must not interleave with close()

### DIFF
--- a/reacton/core.py
+++ b/reacton/core.py
@@ -1322,29 +1322,33 @@ class _RenderContext:
             self._remove_element(self.element, default_key="/", parent_key=ROOT_KEY)
             logger.info("Removing elements done.")
             assert self.context is self.context_root
-        if self.container:
-            self.container.close()
-            if isinstance(self.container, widgets.DOMWidget) and self.container.layout is not None:
-                self.container.layout.close()
-        if self._shared_elements:
-            raise RuntimeError(f"Element not cleaned up: {self._shared_elements}")
-        if self._orphans:
-            orphan_widgets = set([_get_widgets_dict()[k] for k in self._orphans])
-            raise RuntimeError(f"Orphan widgets not cleaned up for widgets: {orphan_widgets}")
-        exceptions = [*self.context.exceptions_children, *self.context_root.exceptions_self]
-        # break the reference cycles through the tree (see _teardown_component_context);
-        # _closing stays True, making stray setters and event handlers no-ops
-        for context in all_contexts:
-            _teardown_component_context(context)
-        self.context = None
-        self.context_root = None  # type: ignore
-        # the root element, container and root widget keep the widget tree alive, and
-        # widgets reference their elements, whose kwargs hold user callbacks - which
-        # capture use_state setters and therefore this render context
-        self.element = None  # type: ignore
-        self.container = None
-        self.last_root_widget = None
-        self._old_element_ids.clear()
+            # everything below used to run outside the lock: a render() that was
+            # blocked on the lock could then interleave with this teardown and
+            # find self.context None mid-render (AssertionError in
+            # Element.__exit__, seen in production behind a prompt kernel close)
+            if self.container:
+                self.container.close()
+                if isinstance(self.container, widgets.DOMWidget) and self.container.layout is not None:
+                    self.container.layout.close()
+            if self._shared_elements:
+                raise RuntimeError(f"Element not cleaned up: {self._shared_elements}")
+            if self._orphans:
+                orphan_widgets = set([_get_widgets_dict()[k] for k in self._orphans])
+                raise RuntimeError(f"Orphan widgets not cleaned up for widgets: {orphan_widgets}")
+            exceptions = [*self.context.exceptions_children, *self.context_root.exceptions_self]
+            # break the reference cycles through the tree (see _teardown_component_context);
+            # _closing stays True, making stray setters and event handlers no-ops
+            for context in all_contexts:
+                _teardown_component_context(context)
+            self.context = None
+            self.context_root = None  # type: ignore
+            # the root element, container and root widget keep the widget tree alive, and
+            # widgets reference their elements, whose kwargs hold user callbacks - which
+            # capture use_state setters and therefore this render context
+            self.element = None  # type: ignore
+            self.container = None
+            self.last_root_widget = None
+            self._old_element_ids.clear()
         if exceptions:
             raise exceptions[0]
 
@@ -1547,6 +1551,12 @@ class _RenderContext:
             self._lock_thread = threading.current_thread()
             if was_locked:
                 logger.info("Mutex released, continuing render phase")
+            if self._closing or self.context is None:
+                # close() won the race for the lock (a disconnect can close the
+                # kernel while an update was waiting to render): the tree is
+                # torn down, there is nothing to render into anymore
+                logger.info("Render requested on a closing/closed render context, ignoring")
+                return container
             prev_rc = getattr(local, "rc", None)
             try:
                 local.rc = self

--- a/reacton/core_test.py
+++ b/reacton/core_test.py
@@ -2963,6 +2963,66 @@ def test_close_when_overridden():
     rc.close()
 
 
+def test_render_after_close_is_noop():
+    # A disconnect can close the kernel while an update is waiting on the render
+    # lock: the late render used to proceed into the torn-down tree and hit
+    # "assert rc.context is not None" in Element.__exit__ (seen in production).
+    # A render on a closed/closing context must be a no-op instead.
+    @react.component
+    def App():
+        value, _set_value = react.use_state(1)
+        return w.Label(value=str(value))
+
+    box, rc = react.render(App(), handle_error=False)
+    rc.close()
+    rc.render(App(), box)  # must not raise, must not render
+
+
+def test_close_render_race():
+    # close() in one thread while renders queue behind the lock in another:
+    # neither thread may raise (the close teardown must not interleave with a
+    # render that was blocked on the lock).
+    import threading
+
+    for _ in range(20):
+
+        @react.component
+        def App():
+            value, _set_value = react.use_state(1)
+            return w.Label(value=str(value))
+
+        box, rc = react.render(App(), handle_error=False)
+        el = App()
+        errors: List[BaseException] = []
+        barrier = threading.Barrier(2)
+
+        def do_render(rc=rc, el=el, box=box, errors=errors, barrier=barrier):
+            try:
+                barrier.wait()
+                rc.render(el, box)
+            except BaseException as e:  # noqa
+                errors.append(e)
+
+        def do_close(rc=rc, errors=errors, barrier=barrier):
+            try:
+                barrier.wait()
+                rc.close()
+            except BaseException as e:  # noqa
+                errors.append(e)
+
+        t1 = threading.Thread(target=do_render)
+        t2 = threading.Thread(target=do_close)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        # whichever won the lock, the loser must not blow up; if render won,
+        # close ran after and the context must still close cleanly
+        if not rc._closing:
+            rc.close()
+        assert not errors, errors
+
+
 def test_render_perf_child_only():
     render_child = unittest.mock.Mock()
     render_main = unittest.mock.Mock()


### PR DESCRIPTION
Seen in production (a large solara application, hours after deploying reacton 1.10.1 + solara 1.60.1): `AssertionError` at `Element.__exit__` (`assert rc.context is not None`), raised mid-render of a component whose `__enter__` had just passed the same assert.

## The race

The `close()` teardown added in #52 runs its tail — including `self.context = None` — **after** the `thread_lock` block ends. Meanwhile `render()` waits for the lock but never re-checks `_closing` after acquiring it. So:

```
render thread: update → render() → lock held by close → waits
disconnect:    close() → locked phase (remove elements, _closing=True) → lock RELEASED
render thread: acquires lock → renders into the torn-down tree
close tail:    (unlocked) self.context = None
render thread: Element.__exit__ → assert rc.context is not None → AssertionError
```

Two changes made this go from theoretical to observed: #52 added the context-nulling tail (1.10.1), and solara closes kernels promptly at disconnect since 1.60 (widgetti/solara#1176) — so close-during-queued-render now actually happens.

## Fix

1. `render()`: after acquiring the lock, no-op (return the container) when `self._closing or self.context is None` — rendering a torn-down tree is meaningless.
2. Belt-and-braces: the whole `close()` teardown tail moves inside the lock, so it cannot interleave with anything. (Closing widgets under the lock is precedented — `_remove_element` already did that.) The `exceptions` re-raise stays outside the lock.

## Tests

- `test_render_after_close_is_noop` — the distilled production scenario.
- `test_close_render_race` — 20 iterations of close-vs-render from two threads behind a barrier; **fails on master** (`AttributeError: 'NoneType' object has no attribute 'exception_handler'` — the same race, different symptom), passes with the fix.
- Full suite: 178 passed in both stock and `REACTON_FAST=1` renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)